### PR TITLE
Fix Hyrule Warriors Rupee Address

### DIFF
--- a/Configs/0100AE00096EA000.json
+++ b/Configs/0100AE00096EA000.json
@@ -6,8 +6,8 @@
 	 {
 		"name" : "Rupee",
 		"category" : "Rupees",
-		"intArgs" : [ 5, 5 ], 
-		"strArgs" : [ "0000", "2B8" ],
+		"intArgs" : [ 4, 4 ], 
+		"strArgs" : [ "0000", "02B8" ],
 		"widget" : {
 			"type" : "int",
 			"minValue" : 0,


### PR DESCRIPTION
Previously it was set to a length and size of 5 which grabbed the wrong value. As can be seen on [this gbatemp thread](https://gbatemp.net/threads/hyrule-warriors-rupee-address.505724/) and to an extend in [iAroc's website editor](https://github.com/iAroc/iAroc.github.io/blob/master/hyruleWarriors/index.html#L209) it should be a length of 4. 

I have also made it `02B8` so it is a proper length of 4 just to standardize.

Note that I had to make this change for the recording for the issue I made to the main repo. If you want to confirm my video from that issue with this game please grab my changed script.