### PR TITLE
Added Hyrule Warriors config

### DIFF
--- a/Configs/0100AE00096EA000.json
+++ b/Configs/0100AE00096EA000.json
@@ -1,0 +1,3453 @@
+{
+  "saveFilePaths": [ "" ],
+  "files": "zmha\\.bin",
+  "filetype": "bin",
+  "items": [
+    {
+      "name": "Rupee",
+      "category": "Rupees",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "02B8" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999999
+      }
+    },
+    {
+      "name": "Metal Plate",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1AFE" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Monster Tooth",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B00" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Old Rag",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B02" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Soldiers Uniform",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B04" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Rock",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B06" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Aeralfos Leather",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B08" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Fiery Aeralfos Leather",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B0A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Gibdo Bandage",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B0C" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "ReDead Bandage",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B0E" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Lizalfos Scale",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B10" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Dinolfos Fang",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B12" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Moblin Flank",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B14" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Shield Moblin Helmet",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B16" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Piece of Darknut Armor",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B18" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Stalmaster Wrist Bone",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B1A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Big Poe Necklace",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B1C" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Essence of Icy Big Poe",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B1E" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Hylian Captain Gauntlet",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B20" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Goron Armor Breastplate",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B22" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Ganons Mane",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B24" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "King Dodongos Claws",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B26" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Gohmas Acid",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B28" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Manhandlas Toxic Dust",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B2A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Argoroks Embers",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B2C" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "The Imprisoneds Scales",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B2E" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Cias Bracelet",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B30" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Volgas Helmet",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B32" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Wizzros Robe",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B34" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Links Boots",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B36" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Lanas Hair Clip",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B38" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Zeldas Brooch",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B3A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Impas Hair Band",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B3C" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Ganondorfs Gauntlet",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B3E" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "UNIDENTIFIED Material 34",
+      "category": "Unidentified Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B40" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "UNIDENTIFIED Material 35",
+      "category": "Unidentified Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B42" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "UNIDENTIFIED Material 36",
+      "category": "Unidentified Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B44" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "UNIDENTIFIED Material 37",
+      "category": "Unidentified Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B46" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "UNIDENTIFIED Material 38",
+      "category": "Unidentified Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B48" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "UNIDENTIFIED Material 39",
+      "category": "Unidentified Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B4A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "UNIDENTIFIED Material 40",
+      "category": "Unidentified Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B4C" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "UNIDENTIFIED Material 41",
+      "category": "Unidentified Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B4E" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Sheiks Kunai",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B40" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Darunias Spikes",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B42" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Rutos Earrings",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B44" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Agithas Basket",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B46" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Midnas Hair",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B48" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Fis Heels",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B4A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Girahims Sash",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B4C" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Zants Magic Gem",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B4E" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Round Aeralfos Shield",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B50" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Fiery Aeralfos Wing",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B52" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Heavy Gibdo Sword",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B54" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "ReDead Knight Ashes",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B56" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Lizalfos Gauntlet",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B58" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Dinolfos Arm Guard",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B5A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Moblin Spear",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B5C" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Metal Moblin Shield",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B5E" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Large Darknut Sword",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B60" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Stalmasters Skull",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B62" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Big Poes Lantern",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B64" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Icey Big Poes Talisman",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B66" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Holy Hylian Shield",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B68" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Thick Goron Helmet",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B6A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Ganons Fang",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B6C" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "King Dodongos Crystal",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B6E" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Gohmas Lens",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B70" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Manhandlas Sapling",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B72" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Argoroks Stone",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B74" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "The Imprisoneds Pillar",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B76" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Cias Staff",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B78" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Volgas Dragon Spear",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B7A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Wizzros Ring",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B7C" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Links Scarf",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B7E" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Lanas Cloak",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B80" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Zeldas Tiara",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B82" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Impas Breastplate",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B84" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Ganondorfs Jewel",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B86" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Sheiks Turban",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B88" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Darunias Bracelet",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B8A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Rutos Scale",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B8C" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Agithas Pendant",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B8E" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Midnas Fused Shadow",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B90" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Fis Crystal",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B92" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Ghirahims Cape",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B94" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Zants Helmet",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B96" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Big Blin Hide",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B98" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Stone Blin Buckler",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B9A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Monster Horn",
+      "category": "Bronze Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B9C" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Big Blin Club",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1B9E" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Stone Blin Helmet",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BA0" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Helmaroc Plume",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BA2" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Phantom Ganons Cape",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BA4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Twili Midnas Hairpin",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BA6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Young Links Boots",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BA8" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Tingles Map",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BAA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Linkles Boots",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BAC" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Skull Kids Hat",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BAE" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Pirates Charm",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BB0" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Tetras Sandals",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BB2" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "King Daphnes Robe",
+      "category": "Silver Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BB4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Helmaroc Kings Mask",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BB6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Phantom Ganons Sword",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BB8" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Twili Midnas Robe",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BBA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Keaton Mask",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BBC" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Tingles Watch",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BBE" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Linkles Compass",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BC0" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Majoras Mask",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BC2" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Island Outfit",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BC4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Tetras Bandana",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BC6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "King Daphnes Crown",
+      "category": "Gold Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BC8" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "UNIDENTIFIED Material 111",
+      "category": "Unidentified Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BCA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "UNIDENTIFIED Material 112",
+      "category": "Unidentified Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BCC" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "UNIDENTIFIED Material 113",
+      "category": "Unidentified Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BCE" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "UNIDENTIFIED Material 114",
+      "category": "Unidentified Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BD0" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "UNIDENTIFIED Material 115",
+      "category": "Unidentified Materials",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "1BD2" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 999
+      }
+    },
+    {
+      "name": "Link - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33084" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Link - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33086" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Link - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3308A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Link - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3308C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Link - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33094" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Link - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33095" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Zelda - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "330B4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Zelda - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "330B6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Zelda - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "330BA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Zelda - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "330BC" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Zelda - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "330C4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Zelda - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "330C5" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Shiek - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "330E4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Shiek - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "330E6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Shiek - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "330EA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Shiek - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "330EC" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Shiek - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "330F4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Shiek - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "330F5" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Impa - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33114" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Impa - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33116" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Impa - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3311A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Impa - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3311C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Impa - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33124" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Impa - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33125" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Ganondorf - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33144" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Ganondorf - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33146" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Ganondorf - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3314A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Ganondorf - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3314C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Ganondorf - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33154" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Ganondorf - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33155" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Darunia - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33174" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Darunia - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33176" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Darunia - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3317A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Darunia - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3317C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Darunia - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33184" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Darunia - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33185" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Ruto - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "331A4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Ruto - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "331A6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Ruto - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "331AA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Ruto - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "331AC" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Ruto - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "331B4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Ruto - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "331B5" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Agitha - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "331D4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Agitha - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "331D6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Agitha - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "331DA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Agitha - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "331DC" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Agitha - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "331E4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Agitha - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "331E5" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Midna - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33204" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Midna - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33206" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Midna - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3320A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Midna - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3320C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Midna - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33214" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Midna - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33215" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Fi - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33234" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Fi - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33236" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Fi - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3323A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Fi - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3323C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Fi - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33244" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Fi - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33245" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Ghirahim - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33264" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Ghirahim - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33266" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Ghirahim - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3326A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Ghirahim - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3326C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Ghirahim - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33274" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Ghirahim - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33275" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Zant - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33294" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Zant - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33296" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Zant - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3329A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Zant - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3329C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Zant - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "332A4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Zant - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "332A5" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Lana - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "332C4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Lana - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "332C6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Lana - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "332CA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Lana - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "332CC" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Lana - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "332D4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Lana - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "332D5" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Cia - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "332F4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Cia - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "332F6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Cia - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "332FA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Cia - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "332FC" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Cia - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33304" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Cia - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33305" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Volga - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33324" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Volga - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33326" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Volga - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3332A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Volga - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3332C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Volga - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33334" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Volga - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33335" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Wizzro - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33354" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Wizzro - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33356" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Wizzro - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3335A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Wizzro - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3335C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Wizzro - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33364" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Wizzro - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33365" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Twili Midna - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33384" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Twili Midna - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33386" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Twili Midna - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3338A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Twili Midna - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3338C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Twili Midna - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33394" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Twili Midna - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33395" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Young Link - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "333B4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Young Link - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "333B6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Young Link - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "333BA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Young Link - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "333BC" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Young Link - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "333C4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Young Link - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "333C5" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Tingle - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "333E4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Tingle - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "333E6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Tingle - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "333EA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Tingle - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "333EC" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Tingle - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "333F4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Tingle - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "333F5" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Ganon - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33414" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Ganon - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33416" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Ganon - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3341A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Ganon - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3341C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Ganon - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33424" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Ganon - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33425" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Cucco - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33444" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Cucco - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33446" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Cucco - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3344A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Cucco - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3344C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Cucco - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33454" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Cucco - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33455" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Linkle - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33474" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Linkle - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33476" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Linkle - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3347A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Linkle - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3347C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Linkle - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33484" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Linkle - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33485" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Skull Kid - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "334A4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Skull Kid - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "334A6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Skull Kid - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "334AA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Skull Kid - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "334AC" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Skull Kid - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "334B4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Skull Kid - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "334B5" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Toon Link - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "334D4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Toon Link - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "334D6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Toon Link - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "334DA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Toon Link - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "334DC" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Toon Link - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "334E4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Toon Link - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "334E5" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Tetra - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33504" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Tetra - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33506" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Tetra - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3350A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Tetra - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3350C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Tetra - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33514" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Tetra - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33515" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "King Daphnes - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33534" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "King Daphnes - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33536" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "King Daphnes - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3353A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "King Daphnes - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3353C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "King Daphnes - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33544" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "King Daphnes - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33545" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Medli - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33564" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Medli - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33566" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Medli - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3356A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Medli - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3356C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Medli - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33574" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Medli - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33575" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Marin - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33594" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Marin - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33596" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Marin - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3359A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Marin - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3359C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Marin - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "335A4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Marin - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "335A5" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Toon Zelda - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "335C4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Toon Zelda - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "335C6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Toon Zelda - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "335CA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Toon Zelda - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "335CC" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Toon Zelda - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "335D4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Toon Zelda - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "335D5" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Ravio - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "335F4" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Ravio - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "335F6" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Ravio - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "335FA" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Ravio - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "335FC" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Ravio - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33604" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Ravio - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33605" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    },
+    {
+      "name": "Yuga - Unlocked",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33624" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 1
+      }
+    },
+    {
+      "name": "Yuga - Attack",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "33626" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 9999
+      }
+    },
+    {
+      "name": "Yuga - Health",
+      "category": "Character Edit",
+      "intArgs": [ 2, 2 ],
+      "strArgs": [ "0000", "3362A" ],
+      "widget": {
+        "type": "int",
+        "minValue": 0,
+        "maxValue": 99999
+      }
+    },
+    {
+      "name": "Yuga - Experience(level up on kill)",
+      "category": "Character Edit",
+      "intArgs": [ 4, 4 ],
+      "strArgs": [ "0000", "3362C" ],
+      "widget": {
+        "type": "list",
+        "listItemNames": [
+          "1 Kill Sets 255 Level (IRREVERSIBLE!)"
+        ],
+        "listItemValues": [
+          12842457
+        ]
+      }
+    },
+    {
+      "name": "Yuga - Level",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33634" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 255
+      }
+    },
+    {
+      "name": "Yuga - HeartContainers",
+      "category": "Character Edit",
+      "intArgs": [ 1, 1 ],
+      "strArgs": [ "0000", "33635" ],
+      "widget": {
+        "type": "int",
+        "minValue": 1,
+        "maxValue": 3
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Config files go into the `/EdiZon/editor` folder, Script files go into the `/Edi
 | [Hollow Knight](https://github.com/WerWolv98/EdiZon_ConfigsAndScripts/blob/master/Configs/0100633007D48000.json)                   | json.lua & lib/json.lua | WerWolv  |
 | [Octopath Traveler Prologue Demo](https://github.com/WerWolv98/EdiZon_ConfigsAndScripts/blob/master/Configs/010096000B3EA000.json) | octp.lua                | shahmirn and SleepyPrince |
 | [BOTW](https://github.com/WerWolv98/EdiZon_ConfigsAndScripts/blob/master/Configs/01007EF00011E000.json)    | bin.lua | borntohonk |
+| [Hyrule Warriors: Definitive Edition](https://github.com/WerWolv98/EdiZon_ConfigsAndScripts/blob/master/Configs/0100AE00096EA000.json) | bin.lua | borntohonk and loganavatar |
 | [Bayonetta 1](https://github.com/WerWolv98/EdiZon_ConfigsAndScripts/blob/master/Configs/010076F0049A2000.json) | bin.lua | madhatter |
 | [Bayonetta 2](https://github.com/WerWolv98/EdiZon_ConfigsAndScripts/blob/master/Configs/01007960049A0000.json) | bin.lua | madhatter |
 | [Mario + Rabbids : Kingdom Battle](https://github.com/WerWolv98/EdiZon_ConfigsAndScripts/blob/master/Configs/010067300059A000.json) | json.lua | madhatter |


### PR DESCRIPTION
# ChangeLog
- With EdiZon 1.3.2, Hyrule Warriors editing no longer locks out the save file.  The original HW config was used as a base, with additional items added under "Character Edit".
- The README.md was updated to include the HW information.

# Previous Behavior
Prior to EdiZon 1.3.2, when playing Hyrule Warriors with an edited save, the save would not be updated with changes or progress, including settings.

# Expected Behavior
Using EdiZon 1.3.2 +, the software should be able to save changes or progress.

# Test Validation
1. Backup the save file.
1. Modify the save using EdiZon and the new .json config.
1. Load Hyrule Warriors, go to Settings, and change a setting.
1. Exit to main Switch Menu and close the Hyrule Warriors software.
1. Load Hyrule Warriors again, and verify that the changed setting persisted with the new value.

