### PR TITLE
Base for Super Bomberman R added

### DIFF
--- a/Configs/01007AD00013E000.json
+++ b/Configs/01007AD00013E000.json
@@ -1,0 +1,127 @@
+{
+	"saveFilePaths": [""],
+	"files": "systemData",
+	"filetype": "bin",
+	"items": [{
+			"name": "Coins",
+			"category": "1. Main",
+			"intArgs": [2, 4],
+			"strArgs": ["0000", "0458"],
+			"widget": {
+				"type": "int",
+				"minValue": 0,
+				"maxValue": 999999999
+			}
+		}, {
+			"name": "Unlock Levels",
+			"category": "1. Main",
+			"intArgs": [2, 3],
+			"strArgs": ["0000", "0450"],
+			"widget": {
+				"type": "list",
+				"listItemNames": ["Reset", "Unlock All"],
+				"listItemValues": [0, 16777215]
+			}
+		}, {
+			"name": "Accessories 01-02",
+			"category": "2. Accessories",
+			"intArgs": [2, 1],
+			"strArgs": ["0000", "0440"],
+			"widget": {
+				"type": "list",
+				"listItemNames": ["None", "1 Full", "2 Full", "All Full"],
+				"listItemValues": [0, 128, 8, 136]
+			}
+		}, {
+			"name": "Accessories 03-04",
+			"category": "2. Accessories",
+			"intArgs": [2, 1],
+			"strArgs": ["0000", "0441"],
+			"widget": {
+				"type": "list",
+				"listItemNames": ["None", "3 Full", "4 Full", "All Full"],
+				"listItemValues": [0, 128, 8, 136]
+			}
+		}, {
+			"name": "Accessories 05-06",
+			"category": "2. Accessories",
+			"intArgs": [2, 1],
+			"strArgs": ["0000", "0442"],
+			"widget": {
+				"type": "list",
+				"listItemNames": ["None", "5 Full", "6 Full", "All Full"],
+				"listItemValues": [0, 128, 8, 136]
+			}
+		}, {
+			"name": "Accessories 07-08",
+			"category": "2. Accessories",
+			"intArgs": [2, 1],
+			"strArgs": ["0000", "0443"],
+			"widget": {
+				"type": "list",
+				"listItemNames": ["None", "7 Full", "8 Full", "All Full"],
+				"listItemValues": [0, 128, 8, 136]
+			}
+		}, {
+			"name": "Accessories 09-10",
+			"category": "2. Accessories",
+			"intArgs": [2, 1],
+			"strArgs": ["0000", "0444"],
+			"widget": {
+				"type": "list",
+				"listItemNames": ["None", "9 Full", "10 Full", "All Full"],
+				"listItemValues": [0, 128, 8, 136]
+			}
+		}, {
+			"name": "Accessories 11-12",
+			"category": "2. Accessories",
+			"intArgs": [2, 1],
+			"strArgs": ["0000", "0445"],
+			"widget": {
+				"type": "list",
+				"listItemNames": ["None", "11 Full", "12 Full", "All Full"],
+				"listItemValues": [0, 128, 8, 136]
+			}
+		}, {
+			"name": "Accessories 13-14",
+			"category": "2. Accessories",
+			"intArgs": [2, 1],
+			"strArgs": ["0000", "0446"],
+			"widget": {
+				"type": "list",
+				"listItemNames": ["None", "13 Full", "14 Full", "All Full"],
+				"listItemValues": [0, 128, 8, 136]
+			}
+		}, {
+			"name": "Accessories 15-16",
+			"category": "2. Accessories",
+			"intArgs": [2, 1],
+			"strArgs": ["0000", "0447"],
+			"widget": {
+				"type": "list",
+				"listItemNames": ["None", "15 Full", "16 Full", "All Full"],
+				"listItemValues": [0, 128, 8, 136]
+			}
+		}, {
+			"name": "Accessories 17-18",
+			"category": "2. Accessories",
+			"intArgs": [2, 1],
+			"strArgs": ["0000", "0448"],
+			"widget": {
+				"type": "list",
+				"listItemNames": ["None", "17 Full", "18 Full", "All Full"],
+				"listItemValues": [0, 128, 8, 136]
+			}
+		}, {
+			"name": "Accessories 19-20",
+			"category": "2. Accessories",
+			"intArgs": [2, 1],
+			"strArgs": ["0000", "0449"],
+			"widget": {
+				"type": "list",
+				"listItemNames": ["None", "19 Full", "20 Full", "All Full"],
+				"listItemValues": [0, 128, 8, 136]
+			}
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Before submitting a script file, please vetify that it works with EdiZon. Change
 | [Mario Tennis Aces](https://github.com/WerWolv98/EdiZon_ConfigsAndScripts/blob/master/Configs/0100BDE00862A000.json) | bin.lua | cubex |
 | [I am Setsuna](https://github.com/WerWolv98/EdiZon_ConfigsAndScripts/blob/master/Configs/0100849000BDA000.json) | setsuna.lua & lib/md5.lua | JojoTheGoat |
 | [Puyo Puyo Tetris](https://github.com/WerWolv98/EdiZon_ConfigsAndScripts/blob/master/Configs/010053D0001BE000.json) | puyopuyo.lua & lib/checksum.lua | JojoTheGoat |
+| [Super Bomberman R](https://github.com/WerWolv98/EdiZon_ConfigsAndScripts/blob/master/Configs/01007AD00013E000.json) | bin.lua | JojoTheGoat |
 
 
 ## All Editor Script files


### PR DESCRIPTION
We have 2 categories Main and Accessories for the Shop yet

The Accessories needs improvement by modifying bin.lua (nibbles support) and are not translated yet

I don't have the latest version of the game and missing a complete save game to find the addresses to unlock all characters (which would be the 3th category)

Looks like the format has not been changed from 1.0.0 to the latest version but I tested on 1.4.1 only!